### PR TITLE
New client for Azure Image Testing for Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ cython_debug/
 
 # credetials
 creds.env
+
+# vscode
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Penguinator CLI
+# Azure Image Testing for Linux CLI
 
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/penguinator-cli)
 
-A Python API client for the Penguinator API: https://penguinatorstarter.powerappsportals.com/webapis2/
+A Python API client for the Azure Image Testing for Linux API. (Azure Image Testing for Linux is a Microsoft Azure Service.)
 
 ## Usage
 
@@ -12,25 +12,23 @@ First, set the following environment variables:
 export AZURE_TENANT_ID=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
 export AZURE_CLIENT_ID=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
 export AZURE_CLIENT_SECRET='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+export AZURE_SUBSCRIPTION_ID=
+export AZURE_RESOURCE_GROUP=
 ```
 
 ```bash
-Usage: penguinator-cli [OPTIONS] COMMAND [ARGS]...
-
-  CLI client for the Penguinator API
-  (https://penguinatorstarter.powerappsportals.com/webapis2/)
+Usage: penguinator-cli COMMAND [OPTIONS] [ARGS]...
 
 Options:
   --help  Show this message and exit.
 
 Commands:
   create-job          Create a new test job
+  create-jobtemplate  Create a new test job template
   get-job             Get a test job.
-  get-projects        Get a test project
-  list-jobs           List all the test jobs
-  list-projects       List all the test projects
-  list-subscriptions  List the subscriptions that can be used for testing
-  list-test-suites    List the test suite available
+  get-jobtemplate     Get a test job template.
+  list-jobs           List all the test jobs.
+  list-jobtemplates   List all the test job templates.
 ```
 
 ## Installation

--- a/cli/main.py
+++ b/cli/main.py
@@ -1,25 +1,104 @@
 import requests
 import click
 import os
-import urllib
 import json
 
-API_BASE_URL = 'https://penguinatorapi2.azure-api.net/'
+
+RESOURCE_PROVIDER = "Microsoft.AzureImageTestingForLinux"
+API_VERSION = "2023-08-01-preview"
 
 TENANT_ID = os.getenv("AZURE_TENANT_ID")
 SUBSCRIPTION_ID = os.getenv("AZURE_SUBSCRIPTION_ID")
 CLIENT_ID = os.getenv("AZURE_CLIENT_ID")
 CLIENT_SECRET = os.getenv("AZURE_CLIENT_SECRET")
+RESOURCE_GROUP = os.getenv("AZURE_RESOURCE_GROUP")
+
+
+def _get_endpoint(segment, **kwargs):
+    resource_group = kwargs.get("resource_group")
+    return (
+        f"https://eastus2euap.management.azure.com/subscriptions/{SUBSCRIPTION_ID}/"
+        f"resourceGroups/{resource_group}/providers/{RESOURCE_PROVIDER}/"
+        f"{segment}?api-version={API_VERSION}"
+    )
+
+
+def _common_options(func):
+    options = [
+        click.option(
+            "--resource-group",
+            "-rg",
+            default=RESOURCE_GROUP,
+            help="Azure Resource Group name",
+        ),
+    ]
+    return _apply_options(func, options)
+
+
+def _template_options(func):
+    options = [
+        click.option("--vm-size", "-s", help="VM size"),
+        click.option("--priority", "-p", help="Test case priority"),
+        click.option("--case-name", "-c", help="Test case names"),
+        click.option(
+            "--location",
+            "-l",
+            default="westus3",
+            help="job template location, it's not required to be changed",
+        ),
+    ]
+    return _apply_options(func, options)
+
+
+def _apply_options(func, options):
+    for option in reversed(options):
+        func = option(func)
+    return func
+
+
+def _create_template(vm_size, priority, case_name, location):
+    template = {
+        "templateTags": [],
+    }
+
+    selection = {}
+    if priority:
+        selection["casePriority"] = [int(x) for x in priority.split(",") if x]
+    if case_name:
+        selection["caseName"] = [x for x in case_name.split(",") if x]
+
+    if selection:
+        template["selections"] = [selection]
+    if location:
+        template["region"] = [location]
+    else:
+        template["region"] = []
+    if vm_size:
+        template["vmSize"] = [vm_size]
+    else:
+        template["vmSize"] = []
+
+    return template
+
+
+def _output_result(resp):
+    try:
+        resp.raise_for_status()
+    except:
+        print(resp.json())
+        raise
+
+    print(json.dumps(resp.json(), indent=2))
 
 
 def auth() -> str:
-    auth_url = f"https://login.microsoftonline.com/{TENANT_ID}/oauth2/v2.0/token"
-    scope = "api://7395f717-3e16-4e02-b95f-802a15a82d47/.default"
+    auth_url = f"https://login.microsoftonline.com/{TENANT_ID}/oauth2/token"
+    resource = "https://management.azure.com/"
     data = {
         "grant_type": "client_credentials",
         "client_id": CLIENT_ID,
         "client_secret": CLIENT_SECRET,
-        "scope": scope,
+        "resource": resource,
     }
     resp = requests.post(auth_url, data=data)
     try:
@@ -29,7 +108,7 @@ def auth() -> str:
         raise
 
     resp_json = resp.json()
-    token = resp_json['access_token']
+    token = resp_json["access_token"]
     return token
 
 
@@ -37,193 +116,170 @@ def auth() -> str:
 @click.pass_context
 def cli(ctx):
     """
-    CLI client for the Penguinator API (https://penguinatorstarter.powerappsportals.com/webapis2/)
+    CLI client for the Azure Image Testing for Linux API
     """
     token = auth()
     ctx.obj = dict()
     session = requests.session()
-    session.headers.update({'Authorization': f'Bearer {token}'})
-    ctx.obj['session'] = session
+    session.headers.update({"Authorization": f"Bearer {token}"})
+    ctx.obj["session"] = session
 
 
 @cli.command()
 @click.pass_context
-def list_projects(ctx):
+@_common_options
+def list_jobtemplates(ctx, **kwargs):
     """
-    List all the test projects
+    List all the test job templates.
     """
-    endpoint = urllib.parse.urljoin(API_BASE_URL, "projects")
+    endpoint = _get_endpoint("jobTemplates", **kwargs)
 
-    session = ctx.obj['session']
+    session = ctx.obj["session"]
 
     resp = session.get(endpoint)
-    try:
-        resp.raise_for_status()
-    except:
-        print(resp.json())
-        raise
-
-    print(json.dumps(resp.json()))
+    _output_result(resp)
 
 
 @cli.command()
 @click.pass_context
-@click.option('--project-id', '-p', required=True)
-def get_projects(ctx, project_id: str):
+@_common_options
+@click.option("--name", "-n", help="job template name", required=True)
+def get_jobtemplate(ctx, name: str, **kwargs):
     """
-    Get a test project
+    Get a test job template.
     """
-    endpoint = urllib.parse.urljoin(API_BASE_URL, "projects")
+    endpoint = _get_endpoint(f"jobTemplates/{name}", **kwargs)
 
-    session = ctx.obj['session']
-
-    resp = session.get(
-        endpoint,
-        params={'id': project_id}
-    )
-    try:
-        resp.raise_for_status()
-    except:
-        print(resp.json())
-        raise
-
-    print(json.dumps(resp.json()))
-
-
-@cli.command()
-@click.pass_context
-def list_jobs(ctx):
-    """
-    List all the test jobs
-    """
-    endpoint = urllib.parse.urljoin(API_BASE_URL, "jobs")
-
-    session = ctx.obj['session']
+    session = ctx.obj["session"]
 
     resp = session.get(endpoint)
-    try:
-        resp.raise_for_status()
-    except:
-        print(resp.json())
-        raise
-
-    print(json.dumps(resp.json()))
+    _output_result(resp)
 
 
 @cli.command()
 @click.pass_context
-@click.option('--job-id', '-j', required=True)
-def get_job(ctx, job_id: str):
+@_common_options
+@click.option("--name", "-n", help="job template name", required=True)
+@_template_options
+def create_jobtemplate(
+    ctx, name: str, vm_size: str, priority: str, case_name: str, location: str, **kwargs
+):
+    """
+    Create a new test job template
+    """
+    endpoint = _get_endpoint(f"jobTemplates/{name}", **kwargs)
+
+    session = ctx.obj["session"]
+
+    template = _create_template(vm_size, priority, case_name, location)
+
+    payload = {"location": location, "name": name, "properties": template}
+    resp = session.put(endpoint, json=payload)
+    _output_result(resp)
+
+
+@cli.command()
+@click.pass_context
+@_common_options
+def list_jobs(ctx, **kwargs):
+    """
+    List all the test jobs.
+    """
+    endpoint = _get_endpoint("jobs", **kwargs)
+
+    session = ctx.obj["session"]
+
+    resp = session.get(endpoint)
+    _output_result(resp)
+
+
+@cli.command()
+@click.pass_context
+@_common_options
+@click.option("--name", "-n", required=True)
+def get_job(ctx, name: str, **kwargs):
     """
     Get a test job. Can be used to get the current status of the job.
     """
-    endpoint = urllib.parse.urljoin(API_BASE_URL, "jobs")
+    endpoint = _get_endpoint(f"jobs/{name}", **kwargs)
 
-    session = ctx.obj['session']
+    session = ctx.obj["session"]
 
-    resp = session.get(
-        endpoint,
-        params={'id': job_id}
-    )
-    try:
-        resp.raise_for_status()
-    except:
-        print(resp.json())
-        raise
-
-    print(json.dumps(resp.json()))
+    resp = session.get(endpoint)
+    _output_result(resp)
 
 
 @cli.command()
 @click.pass_context
-def list_subscriptions(ctx):
-    """
-    List the subscriptions that can be used for testing
-    """
-    endpoint = urllib.parse.urljoin(API_BASE_URL, "subscriptions")
-
-    session = ctx.obj['session']
-
-    resp = session.get(
-        endpoint,
-    )
-    try:
-        resp.raise_for_status()
-    except:
-        print(resp.json())
-        raise
-
-    print(json.dumps(resp.json()))
-
-
-@cli.command()
-@click.pass_context
-def list_test_suites(ctx):
-    """
-    List the test suite available
-    """
-    endpoint = urllib.parse.urljoin(API_BASE_URL, "suites")
-
-    session = ctx.obj['session']
-
-    resp = session.get(
-        endpoint,
-    )
-    try:
-        resp.raise_for_status()
-    except:
-        print(resp.json())
-        raise
-
-    print(json.dumps(resp.json()))
-
-
-@cli.command()
-@click.pass_context
-@click.option('--project', '-p', required=True, help='ID of the test project to use')
-@click.option('--test-suite', '-t', required=True, help='Test suite to use')
-@click.option('--subscription', '-s', required=True, help='Internal penguinator ID of the "subscription" to use')
-@click.option('--marketplace-image-urn', '-u', type=str, help='URN of the image ("az vm image list -p Canonical --all")')
-@click.option('--vhd-sas-url', '-v', type=str, help='SAS URL of a VHD to test')
-@click.option('--vm-generation', '-g', default=2, type=int, help="Hyper-V generation (1 or 2)")
-@click.option('--vm-size', '-m', help="VM size")
-def create_job(ctx, project: str, test_suite: str, subscription: str, marketplace_image_urn: str, vhd_sas_url: str, vm_generation: int, vm_size: str):
+@_common_options
+@click.option("--name", "-n", required=True, help="job name")
+@click.option(
+    "--marketplace-image-urn",
+    "-u",
+    help='URN of the image ("az vm image list -p Canonical --all")',
+)
+@click.option("--vhd-sas-url", "-v", type=str, help="SAS URL of a VHD to test")
+@click.option(
+    "--vm-generation", "-g", default=2, type=int, help="Hyper-V generation (1 or 2)"
+)
+@click.option("--template-name", "-t", type=str, help="job template name")
+@_template_options
+def create_job(
+    ctx,
+    name: str,
+    marketplace_image_urn,
+    vhd_sas_url: str,
+    template_name: str,
+    vm_generation: int,
+    vm_size: str,
+    priority: str,
+    case_name: str,
+    location: str,
+    **kwargs,
+):
     """
     Create a new test job
     """
-    endpoint = urllib.parse.urljoin(API_BASE_URL, "jobs")
+    endpoint = _get_endpoint(f"jobs/{name}", **kwargs)
 
-    session = ctx.obj['session']
-    payload = {
-        'test_project': project,
-        'test_suite': test_suite,
-        'azure_subscription': subscription,
-        'vm_generation': vm_generation,
+    session = ctx.obj["session"]
+
+    image = {
+        "vhdGeneration": vm_generation,
+        "architecture": "x64",
     }
-
     if marketplace_image_urn:
-        payload['marketplace_image_urn'] = marketplace_image_urn
+        image["type"] = "marketplace"
+        image_parts = marketplace_image_urn.split(":")
+        if len(image_parts) != 4:
+            raise ValueError(
+                "marketplace_image_urn should be in the format of 'publisher:offer:sku:version'"
+            )
+        image["publisher"] = image_parts[0]
+        image["offer"] = image_parts[1]
+        image["sku"] = image_parts[2]
+        image["version"] = image_parts[3]
     elif vhd_sas_url:
-        payload['vhd_sas_url'] = vhd_sas_url
+        image["type"] = "vhd"
+        image["url"] = vhd_sas_url
     else:
         raise ValueError(
             "One of --vhd-sas-url or --marketplace-image-urn should be passed."
         )
 
-    if vm_size:
-        payload['vm_size'] = vm_size
+    template = _create_template(vm_size, priority, case_name, location)
 
-    resp = session.post(
-        endpoint,
-        json=payload
-    )
-    try:
-        resp.raise_for_status()
-    except:
-        print(resp.json())
-        raise
+    payload = {
+        "location": location,
+        "properties": {
+            "jobTemplateName": template_name,
+            "jobTemplateInstance": template,
+            "image": image,
+        },
+    }
 
-    print(json.dumps(resp.json()))
+    resp = session.put(endpoint, json=payload)
+    _output_result(resp)
 
 
 if __name__ == "___main__":

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,10 +3,10 @@ name = penguinator-cli
 version = 0.1.0
 author = Gauthier Jolly
 author_email = gauthier.jolly@canonical.com
-description = Basic Penguinator API client
+description = Basic Azure Image Testing for Linux API client
 long_description = file: README.md
 long_description_content_type = text/markdown
-keywords = penguinator, azure
+keywords = penguinator, azure, aitl
 license = GPLv3
 classifiers =
     License :: OSI Approved :: GNU General Public License v3 (GPLv3)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,9 +1,9 @@
 name: penguinator-cli
 base: core22
 version: '0.1'
-summary: A CLI client for Azure's Penguinator API
+summary: A CLI client for Azure Image Testing for Linux API
 description: |
-  Penguinator CLI is a light CLI client for the Penguinator API
+  Azure Image Testing for Linux Client is a light CLI client for the Azure Image Testing for Linux API
 
   https://penguinatorstarter.powerappsportals.com/webapis2/
 


### PR DESCRIPTION
Hello all,

I'm glad to let you all know, Azure Image Testing for Linux is in private preview. It's the next version of Penguinator. It provides standard Azure resource experience, including API standard, reliability, auth/z, tool/SDK (coming later), etc. Please work with our PM to get the onboarding document.

To minimize your efforts to migrate, I created the PR to call new APIs. The design of new API is changed to be simpler. But it's not the same as previous one. So, it needs to adjust the pipeline.

As the same time, I recommend using below AITL wrapper, which is similar to the az CLI experience. It can format output by JMESPath, fetch template file, etc. We will continue to support it, until it's integrated within az CLI.
https://github.com/microsoft/lisa/tree/main/microsoft/utils/aitl

Feel free to let me know, if there is any question.

Best regards,
Chi